### PR TITLE
Update Jena dependencies to resolve security issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,23 +100,22 @@
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-arq</artifactId>
-            <!-- version 4.0.0 is compiled with Java 11 (55), incompatible with 8 (52) -->
-            <version>3.17.0</version>
+            <version>4.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-base</artifactId>
-            <version>3.17.0</version>
+            <version>4.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-core</artifactId>
-            <version>3.17.0</version>
+            <version>4.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-rdfconnection</artifactId>
-            <version>3.17.0</version>
+            <version>4.2.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
To update jena dependencies "Bump jena-core from 3.17.0 to 4.2.0" reported by Dependabot alerts.

I have tested by https://docs.aws.amazon.com/neptune/latest/userguide/iam-auth-connecting-sparql-java.html
```
mvn compile exec:java \
    -Dexec.mainClass="com.amazonaws.neptune.client.jena.NeptuneJenaSigV4Example" \
    -Dexec.args="https://your-neptune-endpoint:port"
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
