### PR TITLE
Bump to 3.0.0-SNAPSHOT and AWS SDK 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <groupId>com.amazonaws</groupId>
     <artifactId>amazon-neptune-sparql-java-sigv4</artifactId>
     <packaging>jar</packaging>
-    <version>2.4.0</version>
+    <version>3.0.0-SNAPSHOT</version>
 
     <name>amazon-neptune-sparql-java-sigv4</name>
     <description>
@@ -66,8 +66,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 
     <dependencyManagement>

--- a/src/main/java/com/amazonaws/neptune/client/jena/NeptuneJenaSigV4Example.java
+++ b/src/main/java/com/amazonaws/neptune/client/jena/NeptuneJenaSigV4Example.java
@@ -15,11 +15,9 @@
 
 package com.amazonaws.neptune.client.jena;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.neptune.auth.NeptuneApacheHttpSigV4Signer;
 import com.amazonaws.neptune.auth.NeptuneSigV4SignerException;
-import com.amazonaws.util.StringUtils;
+import software.amazon.awssdk.utils.StringUtils;
 import org.apache.http.HttpException;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpRequestInterceptor;
@@ -30,6 +28,8 @@ import org.apache.http.protocol.HttpContext;
 import org.apache.jena.rdfconnection.RDFConnection;
 import org.apache.jena.rdfconnection.RDFConnectionRemote;
 import org.apache.jena.rdfconnection.RDFConnectionRemoteBuilder;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 
 /*
  * Example of a building a remote connection
@@ -38,7 +38,7 @@ public class NeptuneJenaSigV4Example {
 
     public static void main(String... args) throws NeptuneSigV4SignerException {
 
-        if (args.length == 0 || StringUtils.isNullOrEmpty(args[0])) {
+        if (args.length == 0 || StringUtils.isEmpty(args[0])) {
             System.err.println("Please specify your endpoint as program argument "
                     + "(e.g.: http://<your_neptune_endpoint>:<your_neptune_endpoint>)");
             System.exit(1);
@@ -47,7 +47,7 @@ public class NeptuneJenaSigV4Example {
         final String endpoint = args[0];
 
         final String regionName = "us-east-1";
-        final AWSCredentialsProvider awsCredentialsProvider = new DefaultAWSCredentialsProviderChain();
+        final AwsCredentialsProvider awsCredentialsProvider = DefaultCredentialsProvider.create();
 
         final NeptuneApacheHttpSigV4Signer v4Signer = new NeptuneApacheHttpSigV4Signer(regionName, awsCredentialsProvider);
 

--- a/src/main/java/com/amazonaws/neptune/client/rdf4j/NeptuneRdf4JSigV4Example.java
+++ b/src/main/java/com/amazonaws/neptune/client/rdf4j/NeptuneRdf4JSigV4Example.java
@@ -15,10 +15,11 @@
 
 package com.amazonaws.neptune.client.rdf4j;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import com.amazonaws.neptune.auth.NeptuneSigV4SignerException;
-import com.amazonaws.util.StringUtils;
+import software.amazon.awssdk.utils.StringUtils;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
@@ -73,7 +74,7 @@ public final class NeptuneRdf4JSigV4Example {
      */
     public static void main(final String[] args) throws Exception {
 
-        if (args.length == 0 || StringUtils.isNullOrEmpty(args[0])) {
+        if (args.length == 0 || StringUtils.isEmpty(args[0])) {
             System.err.println("Please specify your endpoint as program argument "
                     + "(e.g.: http://<my_neptune_host>:<my_neptune_port>)");
             System.exit(1);
@@ -82,7 +83,7 @@ public final class NeptuneRdf4JSigV4Example {
 
         // example of sending a signed query against the SPARQL endpoint
         // use default SAMPLE_QUERY if not specified from input args
-        final String query = (args.length > 1 && !StringUtils.isNullOrEmpty(args[1])) ? args[1] : SAMPLE_QUERY;
+        final String query = (args.length > 1 && !StringUtils.isEmpty(args[1])) ? args[1] : SAMPLE_QUERY;
         executeSignedQueryRequest(endpoint, query);
     }
 
@@ -95,7 +96,7 @@ public final class NeptuneRdf4JSigV4Example {
     protected static void executeSignedQueryRequest(final String endpointUrl, final String query)
             throws NeptuneSigV4SignerException {
 
-        final AWSCredentialsProvider awsCredentialsProvider = new DefaultAWSCredentialsProviderChain();
+        final AwsCredentialsProvider awsCredentialsProvider = DefaultCredentialsProvider.create();
         final NeptuneSparqlRepository neptuneSparqlRepo =
                 new NeptuneSparqlRepository(endpointUrl, awsCredentialsProvider, TEST_REGION);
 
@@ -120,7 +121,7 @@ public final class NeptuneRdf4JSigV4Example {
     protected static void executeSignedInsertRequest(final String endpointUrl)
             throws NeptuneSigV4SignerException {
 
-        final AWSCredentialsProvider awsCredentialsProvider = new DefaultAWSCredentialsProviderChain();
+        final AwsCredentialsProvider awsCredentialsProvider = DefaultCredentialsProvider.create();
 
         final NeptuneSparqlRepository neptuneSparqlRepo =
                 new NeptuneSparqlRepository(endpointUrl, awsCredentialsProvider, TEST_REGION);

--- a/src/main/java/com/amazonaws/neptune/client/rdf4j/NeptuneSparqlRepository.java
+++ b/src/main/java/com/amazonaws/neptune/client/rdf4j/NeptuneSparqlRepository.java
@@ -15,7 +15,7 @@
 
 package com.amazonaws.neptune.client.rdf4j;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import com.amazonaws.neptune.auth.NeptuneApacheHttpSigV4Signer;
 import com.amazonaws.neptune.auth.NeptuneSigV4Signer;
 import com.amazonaws.neptune.auth.NeptuneSigV4SignerException;
@@ -60,7 +60,7 @@ public class NeptuneSparqlRepository extends SPARQLRepository {
     /**
      * The credentials provider, offering credentials for signing the request.
      */
-    private final AWSCredentialsProvider awsCredentialsProvider;
+    private final AwsCredentialsProvider awsCredentialsProvider;
 
     /**
      * The signature V4 signer used to sign the request.
@@ -92,7 +92,7 @@ public class NeptuneSparqlRepository extends SPARQLRepository {
      * @throws NeptuneSigV4SignerException in case something goes wrong with signer initialization
      */
     public NeptuneSparqlRepository(
-            final String endpointUrl, final AWSCredentialsProvider awsCredentialsProvider,
+            final String endpointUrl, final AwsCredentialsProvider awsCredentialsProvider,
             final String regionName)
             throws NeptuneSigV4SignerException {
 


### PR DESCRIPTION
Upgraded to 3.0.0-SNAPSHOT of the sigv4 signer which used SDK 2 which is heading EOL.  Created a separate 2.x-dev branch for ongoing developing with SDK 1. 
