### PR TITLE
Bump to 4.1.0-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 A SPARQL client for [Amazon Neptune](https://aws.amazon.com/neptune) that includes AWS Signature Version 4 signing. Implemented as an RDF4J repository and Jena HTTP Client. This library relies on [amazon-neptune-sigv4-signer](https://github.com/aws/amazon-neptune-sigv4-signer/).
 
+## ⚠️ SDK v1 Deprecation Notice
+
+As of version 4.1.0, the underlying [amazon-neptune-sigv4-signer](https://github.com/aws/amazon-neptune-sigv4-signer/) no longer transitively pulls in `aws-java-sdk-core` (AWS SDK v1). SDK v1 support is deprecated and will be removed in a future major version.
+
+If you use SDK v1 credentials (`com.amazonaws.auth.AWSCredentialsProvider`), you can still do so by explicitly adding `aws-java-sdk-core` as a dependency in your project. However, we recommend migrating to SDK v2 credentials (`software.amazon.awssdk.auth.credentials.AwsCredentialsProvider`) — for example, `DefaultCredentialsProvider.create()`.
+
 For example usage refer to:
  
 -	[NeptuneJenaSigV4Example.java](https://github.com/aws/amazon-neptune-sparql-java-sigv4/blob/master/src/main/java/com/amazonaws/neptune/client/jena/NeptuneJenaSigV4Example.java) 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <groupId>com.amazonaws</groupId>
     <artifactId>amazon-neptune-sparql-java-sigv4</artifactId>
     <packaging>jar</packaging>
-    <version>4.0.1-SNAPSHOT</version>
+    <version>4.1.0-SNAPSHOT</version>
 
     <name>amazon-neptune-sparql-java-sigv4</name>
     <description>
@@ -134,6 +134,14 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>amazon-neptune-sigv4-signer</artifactId>
             <version>${project.version}</version>
+        </dependency>
+
+        <!-- Required for compilation against sigv4-signer (optional transitive) -->
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-core</artifactId>
+            <version>1.12.772</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- AWS SDK Dependencies -->


### PR DESCRIPTION
Aligns with [amazon-neptune-sigv4-signer](https://github.com/aws/amazon-neptune-sigv4-signer) version bump which deprecates SDK v1.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
