### PR TITLE
Refactor AwsSigningHttpClient to use NeptuneJavaHttpSigV4Signer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,12 +133,6 @@
 
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>http-auth-aws</artifactId>
-            <version>${aws.sdk.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
             <artifactId>regions</artifactId>
             <version>${aws.sdk.version}</version>
         </dependency>
@@ -171,6 +165,19 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.2</version>
+                <configuration>
+                    <argLine>-Djdk.httpclient.allowRestrictedHeaders=host</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <profiles>
         <profile>

--- a/src/main/java/com/amazonaws/neptune/client/jena/AwsSigningHttpClient.java
+++ b/src/main/java/com/amazonaws/neptune/client/jena/AwsSigningHttpClient.java
@@ -15,16 +15,13 @@
 
 package com.amazonaws.neptune.client.jena;
 
+import com.amazonaws.neptune.auth.NeptuneJavaHttpSigV4Signer;
+import com.amazonaws.neptune.auth.NeptuneSigV4SignerException;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-import software.amazon.awssdk.auth.signer.Aws4Signer;
-import software.amazon.awssdk.auth.signer.params.Aws4SignerParams;
-import software.amazon.awssdk.http.SdkHttpFullRequest;
-import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.regions.Region;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.Authenticator;
 import java.net.CookieHandler;
@@ -32,7 +29,6 @@ import java.net.ProxySelector;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -42,117 +38,70 @@ import java.util.concurrent.Executor;
  * AWS Signature Version 4 signing HTTP client for Amazon Neptune SPARQL requests.
  * <p>
  * This class extends the standard Java HttpClient to automatically sign HTTP requests
- * using AWS Signature Version 4 authentication. It's specifically designed for use with
- * Amazon Neptune database instances that require IAM authentication.
+ * using AWS Signature Version 4 authentication via {@link NeptuneJavaHttpSigV4Signer}.
+ * It's specifically designed for use with Amazon Neptune database instances that require
+ * IAM authentication.
  * <p>
  * The client wraps a delegate HttpClient and intercepts requests to add the necessary
- * AWS authentication headers (Authorization and x-amz-date) before forwarding them
- * to the underlying client.
- * <P>
- * A new HTTP client and connection must be created every time the request contains a BODY.
- * </P>
- * 
+ * AWS authentication headers before forwarding them to the underlying client.
+ *
  * @author Charles Ivie
  */
 public class AwsSigningHttpClient extends HttpClient {
 
     /** The underlying HTTP client that handles actual network communication */
     private final HttpClient delegate;
-    
-    /** The request body content used for signature calculation */
-    private final String requestBody;
-    
-    /** AWS credentials provider for obtaining signing credentials */
-    private final AwsCredentialsProvider credentialsProvider;
-    
-    /** AWS service name for signing (typically "neptune-db") */
-    private final String serviceName;
-    
-    /** AWS region where the Neptune instance is located */
-    private final Region region;
+
+    /** The SigV4 signer for java.net.http requests */
+    private final NeptuneJavaHttpSigV4Signer signer;
 
     /**
      * Creates a new AWS signing HTTP client.
-     * 
+     *
      * @param serviceName the AWS service name for signing (e.g., "neptune-db")
      * @param region the AWS region where the Neptune instance is located
      * @param credentialsProvider the AWS credentials provider for authentication
-     * @param requestBody the request body content used for signature calculation
+     * @param requestBody the request body content (unused, kept for API compatibility)
      */
     public AwsSigningHttpClient(
             String serviceName,
             Region region,
             AwsCredentialsProvider credentialsProvider,
             String requestBody) {
-        this.requestBody = requestBody;
-        this.credentialsProvider = credentialsProvider;
-        this.serviceName = serviceName;
-        this.region = region;
-        // The delegate client will handle the actual network communication.
+        try {
+            this.signer = new NeptuneJavaHttpSigV4Signer(region.id(), credentialsProvider, serviceName);
+        } catch (NeptuneSigV4SignerException e) {
+            throw new IllegalArgumentException("Failed to initialize SigV4 signer", e);
+        }
         this.delegate = HttpClient.newHttpClient();
     }
 
-    /**
-     * Sends a synchronous HTTP request with AWS Signature V4 authentication.
-     * 
-     * @param <T> the response body type
-     * @param request the HTTP request to send
-     * @param responseBodyHandler the response body handler
-     * @return the HTTP response
-     * @throws IOException if an I/O error occurs
-     * @throws InterruptedException if the operation is interrupted
-     */
     @Override
     public <T> HttpResponse<T> send(HttpRequest request, HttpResponse.BodyHandler<T> responseBodyHandler)
             throws IOException, InterruptedException {
-        return delegate.send(buildSignedRequest(request), responseBodyHandler);
+        return delegate.send(signRequest(request), responseBodyHandler);
     }
 
-    /**
-     * Sends an asynchronous HTTP request with AWS Signature V4 authentication.
-     * 
-     * @param <T> the response body type
-     * @param request the HTTP request to send
-     * @param responseBodyHandler the response body handler
-     * @return a CompletableFuture containing the HTTP response
-     */
     @Override
     public <T> CompletableFuture<HttpResponse<T>> sendAsync(HttpRequest request, HttpResponse.BodyHandler<T> responseBodyHandler) {
-        return delegate.sendAsync(buildSignedRequest(request), responseBodyHandler);
+        return delegate.sendAsync(signRequest(request), responseBodyHandler);
     }
 
-    /**
-     * Builds a signed HTTP request by adding AWS Signature V4 authentication headers.
-     * 
-     * @param request the original HTTP request
-     * @return a new HTTP request with AWS authentication headers added
-     */
-    private HttpRequest buildSignedRequest(HttpRequest request) {
-        // Create a builder from the original request, copying all headers
-        HttpRequest.Builder signedRequestBuilder = HttpRequest.newBuilder(request, (name, value) -> true);
-
-        // Convert the Java HTTP request to AWS SDK format for signing
-        SdkHttpFullRequest awsRequestForSigning = toSdkRequest(request, requestBody);
-
-        // Configure the AWS Signature V4 signer parameters
-        Aws4SignerParams signerParams = Aws4SignerParams.builder()
-                .awsCredentials(credentialsProvider.resolveCredentials())
-                .signingName(serviceName)
-                .signingRegion(region)
-                .build();
-
-        // Sign the request using AWS Signature V4
-        SdkHttpFullRequest signedSdkRequest = Aws4Signer.create().sign(awsRequestForSigning, signerParams);
-
-        // Add the authentication headers to the original request
-        return signedRequestBuilder
-                .header("Authorization", signedSdkRequest.headers().get("Authorization").get(0))
-                .header("x-amz-date", signedSdkRequest.headers().get("x-amz-date").get(0))
-                .build();
+    @Override
+    public <T> CompletableFuture<HttpResponse<T>> sendAsync(HttpRequest r, HttpResponse.BodyHandler<T> h, HttpResponse.PushPromiseHandler<T> p) {
+        return delegate.sendAsync(signRequest(r), h, p);
     }
 
+    private HttpRequest signRequest(HttpRequest request) {
+        HttpRequest.Builder builder = HttpRequest.newBuilder(request, (name, value) -> true);
+        try {
+            signer.signRequest(builder);
+        } catch (NeptuneSigV4SignerException e) {
+            throw new RuntimeException("Failed to sign request", e);
+        }
+        return builder.build();
+    }
 
-    // Delegate all other abstract methods to the wrapped client
     @Override
     public Optional<CookieHandler> cookieHandler() {
         return delegate.cookieHandler();
@@ -196,47 +145,5 @@ public class AwsSigningHttpClient extends HttpClient {
     @Override
     public Optional<Executor> executor() {
         return delegate.executor();
-    }
-
-    /**
-     * Sends an asynchronous HTTP request with push promise support and AWS Signature V4 authentication.
-     * 
-     * @param <T> the response body type
-     * @param r the HTTP request to send
-     * @param h the response body handler
-     * @param p the push promise handler
-     * @return a CompletableFuture containing the HTTP response
-     */
-    @Override
-    public <T> CompletableFuture<HttpResponse<T>> sendAsync(HttpRequest r, HttpResponse.BodyHandler<T> h, HttpResponse.PushPromiseHandler<T> p) {
-        return delegate.sendAsync(buildSignedRequest(r), h, p);
-    }
-
-    /**
-     * Converts a Java HttpRequest to an AWS SDK SdkHttpFullRequest for signing.
-     * 
-     * @param originalHttpRequest the original Java HTTP request
-     * @param originalBody the request body content
-     * @return an AWS SDK HTTP request ready for signing
-     */
-    private SdkHttpFullRequest toSdkRequest(HttpRequest originalHttpRequest, String originalBody) {
-        // Build the AWS SDK request with URI and HTTP method
-        SdkHttpFullRequest.Builder sdkRequestBuilder = SdkHttpFullRequest.builder()
-                .uri(originalHttpRequest.uri())
-                .method(SdkHttpMethod.fromValue(originalHttpRequest.method()));
-
-        // Add request body if present
-        if (originalHttpRequest.bodyPublisher().isPresent()) {
-            sdkRequestBuilder.contentStreamProvider(() -> new ByteArrayInputStream(originalBody.getBytes(StandardCharsets.UTF_8)));
-        }
-
-        // Copy all headers from the original request
-        originalHttpRequest.headers().map().forEach((headerName, headerValues) -> {
-            for (String headerValue : headerValues) {
-                sdkRequestBuilder.putHeader(headerName, headerValue);
-            }
-        });
-
-        return sdkRequestBuilder.build();
     }
 }


### PR DESCRIPTION
Replace inline Aws4Signer signing logic with delegation to NeptuneJavaHttpSigV4Signer from the sigv4-signer library.

- Removed direct http-auth-aws dependency (now transitive via sigv4-signer)
- Added surefire config for -Djdk.httpclient.allowRestrictedHeaders=host
- Simplified AwsSigningHttpClient from 207 to 149 lines

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
